### PR TITLE
Added "user" label

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name           = "prometheus_folder_size_exporter"
-version        = "0.1.0"
-authors        = ["Francesco Cogno <francesco.cogno@outlook.com>"]
+version        = "0.1.1"
+authors        = ["Francesco Cogno <francesco.cogno@outlook.com>", "Guido Scatena <guido.scatena@unipi.it>"]
 description    = "Prometheus Folder Size Exporter"
-edition        = "2018"
+edition        = "2020"
 
 readme         = "README.md"
 license        = "MIT"
-repository     = "https://github.com/MindFlavor/prometheus_folder_size_exporter"
-documentation  = "https://github.com/MindFlavor/prometheus_folder_size_exporter"
-homepage       = "https://github.com/MindFlavor/prometheus_folder_size_exporter"
+repository     = "https://github.com/scatenag/prometheus_folder_size_exporter"
+documentation  = "https://github.com/scatenag/prometheus_folder_size_exporter"
+homepage       = "https://github.com/scatenag/prometheus_folder_size_exporter"
 
 keywords       = ["prometheus", "exporter", "filesystem", "size", "folder"]
 categories     = ["api-bindings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition        = "2018"
 
 readme         = "README.md"
 license        = "MIT"
-repository     = "https://github.com/scatenag/prometheus_folder_size_exporter"
-documentation  = "https://github.com/scatenag/prometheus_folder_size_exporter"
-homepage       = "https://github.com/scatenag/prometheus_folder_size_exporter"
+repository     = "https://github.com/MindFlavor/prometheus_folder_size_exporter"
+documentation  = "https://github.com/MindFlavor/prometheus_folder_size_exporter"
+homepage       = "https://github.com/MindFlavor/prometheus_folder_size_exporter"
 
 keywords       = ["prometheus", "exporter", "filesystem", "size", "folder"]
 categories     = ["api-bindings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name           = "prometheus_folder_size_exporter"
 version        = "0.1.1"
 authors        = ["Francesco Cogno <francesco.cogno@outlook.com>", "Guido Scatena <guido.scatena@unipi.it>"]
 description    = "Prometheus Folder Size Exporter"
-edition        = "2020"
+edition        = "2018"
 
 readme         = "README.md"
 license        = "MIT"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Francesco Cogno
+Copyright (c) 2019 Francesco Cogno and  2020 Guido Scatena
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example.json
+++ b/example.json
@@ -1,4 +1,4 @@
 [
-  { "path": "/home/mindflavor", "recursive": true },
-  { "path": "/home/mindflavor/.cargo", "recursive": false }
+  { "path": "/home/mindflavor", "recursive": true, "user":  "mindflavor"},
+  { "path": "/home/mindflavor/.cargo", "recursive": false , "user":  "mindflavor"}
 ]

--- a/src/folder_scanner.rs
+++ b/src/folder_scanner.rs
@@ -11,17 +11,17 @@ pub(crate) struct FolderToScan {
 
 impl FolderToScan {
     pub fn scan(&self) -> Result<u64, std::io::Error> {
-        scan_folder(Path::new(&self.path), self.recursive, self.user)
+        scan_folder(Path::new(&self.path), self.recursive, &String::from(&self.user))
     }
 }
 
 #[inline]
-fn scan_folder(dir: &Path, is_recursive: bool, user: String) -> Result<u64, std::io::Error> {
+fn scan_folder(dir: &Path, is_recursive: bool, user: &String) -> Result<u64, std::io::Error> {
     let mut tot: u64 = 0;
     for entry in read_dir(dir)? {
         let entry = entry?;
         if entry.file_type()?.is_dir() && is_recursive {
-            tot += scan_folder(&entry.path(), is_recursive)?;
+            tot += scan_folder(&entry.path(), is_recursive, user)?;
         } else {
             tot += entry.metadata()?.len();
         }

--- a/src/folder_scanner.rs
+++ b/src/folder_scanner.rs
@@ -6,16 +6,17 @@ use std::path::Path;
 pub(crate) struct FolderToScan {
     pub(crate) path: String,
     pub(crate) recursive: bool,
+    pub(crate) user: String,
 }
 
 impl FolderToScan {
     pub fn scan(&self) -> Result<u64, std::io::Error> {
-        scan_folder(Path::new(&self.path), self.recursive)
+        scan_folder(Path::new(&self.path), self.recursive, self.user)
     }
 }
 
 #[inline]
-fn scan_folder(dir: &Path, is_recursive: bool) -> Result<u64, std::io::Error> {
+fn scan_folder(dir: &Path, is_recursive: bool, user: String) -> Result<u64, std::io::Error> {
     let mut tot: u64 = 0;
     for entry in read_dir(dir)? {
         let entry = entry?;
@@ -74,9 +75,9 @@ mod tests {
     fn test_parse() {
         let s = "
 		  	 [
-		  		 { \"path\": \"pippo\", \"recursive\": true },
-		  		 { \"path\": \"pluto\", \"recursive\": true }, 
-		  		 { \"path\": \"paperino\", \"recursive\": false } 
+		  		 { \"path\": \"pippo\", \"recursive\": true, \"user\": \"pippo\" },
+		  		 { \"path\": \"pluto\", \"recursive\": true , \"user\": \"pluto\"}, 
+		  		 { \"path\": \"paperino\", \"recursive\": false , \"user\": \"paperino\"} 
 		  	]
 		  ";
 
@@ -85,6 +86,7 @@ mod tests {
         assert_eq!(dresp.folders().len(), 3);
         assert_eq!(dresp.folders()[0].recursive, true);
         assert_eq!(dresp.folders()[2].path, "paperino");
+        assert_eq!(dresp.folders()[2].user, "paperino");
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,8 @@ fn perform_request(
             let mut s = String::with_capacity(1024);
             for result in v_sizes {
                 s.push_str(&format!(
-                    "folder_size{{path=\"{}\",recursive=\"{}\"}} {}\n",
-                    result.folder.path, result.folder.recursive, result.size
+                    "folder_size{{path=\"{}\",recursive=\"{}\"}, user=\"{}\"}} {}\n",
+                    result.folder.path,  result.folder.recursive, result.folder.user, result.size
                 ));
             }
 
@@ -78,8 +78,8 @@ fn perform_request(
 
 fn main() {
     let matches = clap::App::new("prometheus_folder_size_exporter")
-        .version("0.1")
-        .author("Francesco Cogno <francesco.cogno@outlook.com>")
+        .version("0.1.1")
+        .author("Francesco Cogno <francesco.cogno@outlook.com>  & Guido Scatena <guido.scatena@unipi.it>")
         .arg(
             Arg::with_name("port")
                 .short("p")

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn perform_request(
             let mut s = String::with_capacity(1024);
             for result in v_sizes {
                 s.push_str(&format!(
-                    "folder_size{{path=\"{}\",recursive=\"{}\"}, user=\"{}\"}} {}\n",
+                    "folder_size{{path=\"{}\",recursive=\"{}\", user=\"{}\"}} {}\n",
                     result.folder.path,  result.folder.recursive, result.folder.user, result.size
                 ));
             }


### PR DESCRIPTION
In order to monitor folders size by users,
I added the "user" label.

-----------

I appreciated very much your exporter.

Actually, in more general terms, 
It would be useful to allow more and arbitrary labels to be expressed in the configuration file 
and then reported, as is, by the exporter.

Unfortunately, I am new to Rust and, for the moment, I am not able to do so;
thus I modified only for my need, that is, to have a "user" label. 

It would be nice also to make the "user" label not mandatory.

Any suggestions are welcome!